### PR TITLE
Feat: cookies consent

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -88,6 +88,7 @@
     "superjson": "^2.2.0",
     "uglify-js": "^3.17.4",
     "undici": "^5.27.0",
+    "usehooks-ts": "^2.9.1",
     "uuid": "^9.0.1",
     "zod": "^3.22.4",
     "zustand": "^4.4.5"

--- a/apps/web/src/app/(public)/PublicFooter.tsx
+++ b/apps/web/src/app/(public)/PublicFooter.tsx
@@ -111,6 +111,15 @@ const PublicFooter = () => (
             </a>
           </li>
           <li className="fr-footer__bottom-item">
+            <button
+              className="fr-footer__bottom-link fr-link--icon-left fr-icon-settings-5-line"
+              data-fr-opened="false"
+              aria-controls="fr-consent-modal"
+            >
+              Gestion des cookies
+            </button>
+          </li>
+          <li className="fr-footer__bottom-item">
             <a
               className="fr-footer__bottom-link fr-link--icon-left fr-icon-user-setting-line"
               href="/connexion/login"

--- a/apps/web/src/app/(public)/PublicFooter.tsx
+++ b/apps/web/src/app/(public)/PublicFooter.tsx
@@ -112,6 +112,7 @@ const PublicFooter = () => (
           </li>
           <li className="fr-footer__bottom-item">
             <button
+              id="gestion-des-cookies"
               className="fr-footer__bottom-link fr-link--icon-left fr-icon-settings-5-line"
               data-fr-opened="false"
               aria-controls="fr-consent-modal"

--- a/apps/web/src/app/(public)/layout.tsx
+++ b/apps/web/src/app/(public)/layout.tsx
@@ -1,9 +1,11 @@
 import { PropsWithChildren } from 'react'
 import PublicHeader from '@sde/web/app/(public)/PublicHeader'
 import PublicFooter from '@sde/web/app/(public)/PublicFooter'
+import { CookieConsent } from '@sde/web/components/CookieConsent'
 
 const PublicLayout = ({ children }: PropsWithChildren) => (
   <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100%' }}>
+    <CookieConsent />
     <PublicHeader />
     <div style={{ flex: 1 }}>
       <div>{children}</div>

--- a/apps/web/src/app/Matomo.tsx
+++ b/apps/web/src/app/Matomo.tsx
@@ -1,7 +1,11 @@
 import Script from 'next/script'
 
 // The Next <Script> tag expect a nonce as Next directly inject the code from the script file in an inline <script> tag
-export const Matomo = ({ nonce }: { nonce?: string }) =>
-  process.env.NODE_ENV === 'production' ? (
-    <Script nonce={nonce} src="/matomo/matomo.min.js" strategy="lazyOnload" />
-  ) : null
+export const Matomo = ({ nonce }: { nonce?: string }) => {
+  const isProd = process.env.NODE_ENV === 'production'
+
+  // eslint-disable-next-line no-console
+  !isProd && console.warn('Matomo is disabled in non-production environment')
+
+  return isProd ? <Script nonce={nonce} src="/matomo/matomo.min.js" strategy="lazyOnload" /> : null;
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -51,7 +51,6 @@ const RootLayout = ({ children }: PropsWithChildren) => {
           />
         ))}
         <Dsfr nonce={nonce} />
-        <Matomo nonce={nonce} />
       </head>
       <body>
         <EnvInformation />

--- a/apps/web/src/components/CookieConsent.tsx
+++ b/apps/web/src/components/CookieConsent.tsx
@@ -46,9 +46,8 @@ export const CookieConsent = () => {
             <p className="fr-text--sm">
               Bienvenue ! Nous utilisons des cookies pour améliorer votre expérience et les services disponibles
               sur ce site. Pour en savoir plus, visitez la page <a href="/confidentialite">Confidentialité</a>. 
-              Vous pouvez, à tout moment, avoir le contrôle sur les cookies que vous souhaitez activer.
-              <br/>
-              <b>{JSON.stringify(cookieConsent)}</b>
+              Vous pouvez, à tout moment, avoir le contrôle sur les cookies que vous souhaitez activer en 
+              cliquant sur <a href="#gestion-des-cookies">Gestion des cookies</a> en bas de page.
             </p>
           </div>
           <ul className="fr-consent-banner__buttons fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-sm">

--- a/apps/web/src/components/CookieConsent.tsx
+++ b/apps/web/src/components/CookieConsent.tsx
@@ -1,0 +1,305 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useLocalStorage } from "usehooks-ts"
+import { Matomo } from "../app/Matomo"
+
+type CookieConsentModel = {
+  isSet: boolean
+  consent: {
+    mandatory: true
+    analytics: {
+      matomo: boolean
+    }
+  }
+}
+
+const defaultConsent: CookieConsentModel = {
+  isSet: false,
+  consent: {
+    mandatory: true,
+    analytics: {
+      matomo: false,
+    },
+  },
+};
+
+const fullConsent: CookieConsentModel = {
+  isSet: true,
+  consent: {
+    mandatory: true,
+    analytics: {
+      matomo: true,
+    },
+  }
+}
+
+export const CookieConsent = () => {
+  const [cookieConsent, setCookieConsent] = useLocalStorage<CookieConsentModel>('cookie-consent', defaultConsent)
+  
+  return (
+    <>
+      {!cookieConsent.isSet && (
+        <div className="fr-consent-banner">
+          <h2 className="fr-h6">À propos des cookies sur Solution d&apos;élus</h2>
+          <div className="fr-consent-banner__content">
+            <p className="fr-text--sm">
+              Bienvenue ! Nous utilisons des cookies pour améliorer votre expérience et les services disponibles
+              sur ce site. Pour en savoir plus, visitez la page <a href="/confidentialite">Confidentialité</a>. 
+              Vous pouvez, à tout moment, avoir le contrôle sur les cookies que vous souhaitez activer.
+              <br/>
+              <b>{JSON.stringify(cookieConsent)}</b>
+            </p>
+          </div>
+          <ul className="fr-consent-banner__buttons fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-sm">
+            <li>
+              <button className="fr-btn" title="Autoriser tous les cookies" onClick={() => setCookieConsent(fullConsent) as void}>
+                Tout accepter
+              </button>
+            </li>
+            <li>
+              <button className="fr-btn" title="Refuser tous les cookies" onClick={() => setCookieConsent({...defaultConsent, isSet: true }) as void}>
+                Tout refuser
+              </button>
+            </li>
+            <li>
+              <button className="fr-btn fr-btn--secondary" data-fr-opened="false" aria-controls="fr-consent-modal" title="Personnaliser les cookies">
+                Personnaliser
+              </button>
+            </li>
+          </ul>
+        </div>
+      )}
+
+      {cookieConsent.isSet && (
+        (cookieConsent?.consent?.analytics?.matomo) && (
+          <Matomo nonce={undefined} />
+        )
+      )}
+
+      <CookieModal cookieConsent={cookieConsent} setCookieConsent={setCookieConsent} />
+    </>
+  )
+};
+
+type CookieModalProps = {
+  cookieConsent: CookieConsentModel
+  setCookieConsent: (cookieConsent: CookieConsentModel) => void
+}
+
+export const CookieModal = ({cookieConsent, setCookieConsent}: CookieModalProps) => {
+  const [form, setForm] = useState<CookieConsentModel>(cookieConsent)
+
+  useEffect(() => {
+    setForm(() => cookieConsent)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cookieConsent])
+
+  const handleConfirm = () => {
+    setCookieConsent(form)
+  }
+
+  return (
+    <dialog id="fr-consent-modal" className="fr-modal" role="dialog" aria-labelledby="fr-consent-modal-title">
+      <div className="fr-container fr-container--fluid fr-container-md">
+        <div className="fr-grid-row fr-grid-row--center">
+          <div className="fr-col-12 fr-col-md-10 fr-col-lg-8">
+            <div className="fr-modal__body">
+              <div className="fr-modal__header">
+                <button className="fr-btn--close fr-btn" aria-controls="fr-consent-modal" title="Fermer">
+                  Fermer
+                </button>
+              </div>
+              <div className="fr-modal__content">
+                <h1 id="fr-consent-modal-title" className="fr-modal__title">
+                  Panneau de gestion des cookies
+                </h1>
+                <div className="fr-consent-manager">
+                  {/* Finalités */}
+                  <div className="fr-consent-service fr-consent-manager__header">
+                    <fieldset className="fr-fieldset fr-fieldset--inline">
+                      <legend id="finality-legend" className="fr-consent-service__title">
+                        Préférences pour tous les services. <br/>
+                        <a href="/confidentialite">Données personnelles et cookies</a>
+                      </legend>
+                      <div className="fr-consent-service__radios">
+                        <div className="fr-radio-group">
+                          <input
+                            type="radio"
+                            id="consent-all-accept"
+                            name="consent-all"
+                            checked={form.isSet && Object.values(form.consent).every((finality) => Object.values(finality).every((service) => service === true))}
+                            onChange={(event) => event.target.checked && setForm(fullConsent)}
+                          />
+                          <label className="fr-label" htmlFor="consent-all-accept">
+                            Tout accepter
+                          </label>
+                        </div>
+                        <div className="fr-radio-group">
+                          <input
+                            type="radio"
+                            id="consent-all-refuse"
+                            name="consent-all"
+                            checked={form.isSet && Object.values(form.consent).every((finality) => Object.values(finality).every((service) => service === false))}
+                            onChange={(event) => event.target.checked && setForm({...defaultConsent, isSet: true })}
+                          />
+                          <label className="fr-label" htmlFor="consent-all-refuse">
+                            Tout refuser
+                          </label>
+                        </div>
+                      </div>
+                    </fieldset>
+                  </div>
+                  <div className="fr-consent-service">
+                    <fieldset aria-labelledby="mandatory-legend mandatory-desc" role="group" className="fr-fieldset fr-fieldset--inline">
+                      <legend id="mandatory-legend" className="fr-consent-service__title">Cookies obligatoires</legend>
+                      <div className="fr-consent-service__radios">
+                        <div className="fr-radio-group">
+                          <input disabled defaultChecked type="radio" id="consent-mandatory-accept" name="consent-mandatory"/>
+                          <label className="fr-label" htmlFor="consent-mandatory-accept">Accepter</label>
+                        </div>
+                        <div className="fr-radio-group">
+                          <input disabled type="radio" id="consent-mandatory-refuse" name="consent-mandatory"/>
+                          <label className="fr-label" htmlFor="consent-mandatory-refuse">Refuser</label>
+                        </div>
+                      </div>
+                      <p id="mandatory-desc" className="fr-consent-service__desc">
+                        Ce site utilise des cookies nécessaires à son bon fonctionnement 
+                        qui ne peuvent pas être désactivés.
+                      </p>
+                    </fieldset>
+                  </div>
+                  {/* Analytics */}
+                  <div className="fr-consent-service">
+                    <fieldset aria-labelledby="analytics-legend analytics-desc" role="group" className="fr-fieldset fr-fieldset--inline">
+                      <legend id="analytics-legend" className="fr-consent-service__title">Analyse d&apos;audience</legend>
+                      <div className="fr-consent-service__radios">
+                        <div className="fr-radio-group">
+                          <input
+                            type="radio"
+                            id="consent-analytics-accept"
+                            name="consent-analytics"
+                            checked={form.isSet && Object.values(form.consent.analytics).every((service) => service === true)}
+                            onChange={(event) => event.target.checked && setForm({
+                              isSet: true,
+                              consent: {
+                                ...form.consent,
+                                analytics: {
+                                  matomo: true
+                                }
+                              }
+                            })}
+                          />
+                          <label className="fr-label" htmlFor="consent-analytics-accept">
+                            Accepter
+                          </label>
+                        </div>
+                        <div className="fr-radio-group">
+                          <input
+                            type="radio"
+                            id="consent-analytics-refuse"
+                            name="consent-analytics"
+                            checked={form.isSet && Object.values(form.consent.analytics).every((service) => service === false)}
+                            onChange={(event) => event.target.checked && setForm({
+                              isSet: true,
+                              consent: {
+                                ...form.consent,
+                                analytics: {
+                                  matomo: false
+                                }
+                              }
+                            })}
+                          />
+                          <label className="fr-label" htmlFor="consent-analytics-refuse">
+                            Refuser
+                          </label>
+                        </div>
+                      </div>
+                      <p id="analytics-desc" className="fr-consent-service__desc">
+                        Description optionnelle de la finalité.
+                      </p>
+                      <div className="fr-consent-service__collapse">
+                        <button className="fr-consent-service__collapse-btn" aria-expanded="false" aria-describedby="analytics-legend" aria-controls="analytics-collapse">
+                          Voir plus de détails
+                        </button>
+                      </div>
+                      <div className="fr-consent-services fr-collapse" id="analytics-collapse">
+                        {/* Sous finalités */}
+                        <div className="fr-consent-service">
+                          <fieldset aria-labelledby="analytics-matomo-legend analytics-matomo-desc" role="group" className="fr-fieldset fr-fieldset--inline">
+                            <legend id="analytics-matomo-legend" className="fr-consent-service__title" aria-describedby="analytics-matomo-desc">
+                              Matomo
+                            </legend>
+                            <div className="fr-consent-service__radios fr-fieldset--inline">
+                              <div className="fr-radio-group">
+                                <input
+                                  type="radio"
+                                  id="consent-analytics-matomo-accept"
+                                  name="consent-analytics-matomo"
+                                  checked={form.isSet ? form.consent?.analytics?.matomo : false}
+                                  onChange={(event) => event.target.checked && setForm({
+                                    isSet: true,
+                                    consent: {
+                                      ...form.consent,
+                                      analytics: {
+                                        ...form.consent?.analytics,
+                                        matomo: true
+                                      }
+                                    }
+                                  })}
+                                />
+                                <label className="fr-label" htmlFor="consent-analytics-matomo-accept">
+                                  Accepter
+                                </label>
+                              </div>
+                              <div className="fr-radio-group">
+                                <input
+                                  type="radio"
+                                  id="consent-analytics-matomo-refuse"
+                                  name="consent-analytics-matomo"
+                                  checked={form.isSet ? !form.consent?.analytics?.matomo : false}
+                                  onChange={(event) => event.target.checked && setForm({
+                                    isSet: true,
+                                    consent: {
+                                      ...form.consent,
+                                      analytics: {
+                                        ...form.consent?.analytics,
+                                        matomo: false
+                                      }
+                                    }
+                                  })}
+                                />
+                                <label className="fr-label" htmlFor="consent-analytics-matomo-refuse">
+                                  Refuser
+                                </label>
+                              </div>
+                            </div>
+                            <p id="analytics-matomo-desc" className="fr-consent-service__desc">
+                              Description optionnelle du service.
+                            </p>
+                          </fieldset>
+                        </div>
+                      </div>
+                    </fieldset>
+                  </div>
+                  {/* Bouton de confirmation/fermeture */}
+                  <ul className="fr-consent-manager__buttons fr-btns-group fr-btns-group--right fr-btns-group--inline-sm">
+                    <li>
+                      <button
+                        className="fr-btn"
+                        aria-controls="fr-consent-modal"
+                        onClick={handleConfirm}
+                      >
+                        Confirmer mes choix
+                      </button>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </dialog>
+  )
+}

--- a/apps/web/src/components/CookieConsent.tsx
+++ b/apps/web/src/components/CookieConsent.tsx
@@ -53,12 +53,12 @@ export const CookieConsent = () => {
           </div>
           <ul className="fr-consent-banner__buttons fr-btns-group fr-btns-group--right fr-btns-group--inline-reverse fr-btns-group--inline-sm">
             <li>
-              <button className="fr-btn" title="Autoriser tous les cookies" onClick={() => setCookieConsent(fullConsent) as void}>
+              <button className="fr-btn" title="Autoriser tous les cookies" onClick={() => {setCookieConsent(fullConsent)}}>
                 Tout accepter
               </button>
             </li>
             <li>
-              <button className="fr-btn" title="Refuser tous les cookies" onClick={() => setCookieConsent({...defaultConsent, isSet: true }) as void}>
+              <button className="fr-btn" title="Refuser tous les cookies" onClick={() => {setCookieConsent({...defaultConsent, isSet: true })}}>
                 Tout refuser
               </button>
             </li>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,9 @@ importers:
       undici:
         specifier: ^5.27.0
         version: 5.27.0
+      usehooks-ts:
+        specifier: ^2.9.1
+        version: 2.9.1(react-dom@18.2.0)(react@18.2.0)
       uuid:
         specifier: ^9.0.1
         version: 9.0.1
@@ -21110,6 +21113,17 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
       react: 18.2.0
+    dev: false
+
+  /usehooks-ts@2.9.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==}
+    engines: {node: '>=16.15.0', npm: '>=8'}
+    peerDependencies:
+      react: ^16.8.0  || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0  || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /util-deprecate@1.0.2:


### PR DESCRIPTION
- add cookies consent management banner
- add cookies consent management modal

_at the moment, only Matomo is subject to user's consent_

// TODO
edit `Analyse d'audience` finality and `Matomo` service descriptions